### PR TITLE
bugfix:招待リンク押下時に未ログインだった際の挙動修正

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -20,7 +20,7 @@ export async function joinCircle(formData: FormData) {
   if (!session || !session.user?.id) {
     // 念のため未ログイン時の再チェック
     const callbackUrl = encodeURIComponent(`/join?circleId=${circleId}`);
-    redirect(`/api/auth/signin/google?callbackUrl=${callbackUrl}`);
+    redirect(`/?callbackUrl=${callbackUrl}`);
   }
 
   const userId = session.user.id as string;
@@ -61,10 +61,10 @@ export default async function JoinPage({ searchParams }: JoinPageProps) {
 
   const session = await auth();
 
-  // 未ログインなら Google サインインへ → 戻り先はこの /join
+  // 未ログインならトップページへリダイレクト（callbackUrl付きでログイン後に戻る）
   if (!session || !session.user?.id) {
     const callbackUrl = encodeURIComponent(`/join?circleId=${circleId}`);
-    redirect(`/api/auth/signin/google?callbackUrl=${callbackUrl}`);
+    redirect(`/?callbackUrl=${callbackUrl}`);
   }
 
   const userId = session.user.id as string;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,29 @@
 import { auth, signIn } from "@/auth";
 import { redirect } from "next/navigation";
 
-export default async function HomePage() {
-  const session = await auth();
+type HomePageProps = {
+  searchParams: Promise<{ callbackUrl?: string }>;
+};
 
-  // すでにログインしている場合はダッシュボードへ
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const session = await auth();
+  const { callbackUrl } = await searchParams;
+
+  // すでにログインしている場合
   if (session) {
+    // callbackUrlがあればそちらへ、なければダッシュボードへ
+    if (callbackUrl) {
+      redirect(decodeURIComponent(callbackUrl));
+    }
     redirect("/dashboard");
   }
 
   // ログインボタン用のサーバーアクション
   async function handleGoogleLogin() {
     "use server";
-    await signIn("google");
+    // callbackUrlを取得するためにクロージャで参照
+    const redirectTo = callbackUrl ? decodeURIComponent(callbackUrl) : "/dashboard";
+    await signIn("google", { redirectTo });
   }
 
   return (

--- a/auth.ts
+++ b/auth.ts
@@ -18,7 +18,7 @@ export const {
       if (user.id) {
         await prisma.circle.create({
           data: {
-            name: "",
+            name: "おはじめ",
             currency: "JPY",
             members: {
               create: {


### PR DESCRIPTION
- 招待リンク経由 → ログイン後にサークル参加画面（/join?circleId=xxx）に遷移
- それ以外（トップページに直接アクセスなど）→ ログイン後にダッシュボード（/dashboard）に遷移