### PR TITLE
func:サークル管理機能を追加

### DIFF
--- a/app/api/circles/[circleId]/members/[memberId]/route.ts
+++ b/app/api/circles/[circleId]/members/[memberId]/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import prisma from "@/lib/prisma";
+
+type Params = {
+  params: Promise<{ circleId: string; memberId: string }>;
+};
+
+// メンバーをサークルから削除
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await auth();
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id as string;
+  const { circleId, memberId } = await params;
+
+  // 自分がこのサークルのADMINかチェック
+  const adminMembership = await prisma.circleMember.findUnique({
+    where: {
+      circleId_userId: {
+        circleId,
+        userId,
+      },
+    },
+  });
+
+  if (!adminMembership || adminMembership.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "このサークルの管理権限がありません" },
+      { status: 403 }
+    );
+  }
+
+  // 自分自身は削除できない
+  if (memberId === userId) {
+    return NextResponse.json(
+      { error: "自分自身は削除できません" },
+      { status: 400 }
+    );
+  }
+
+  // 対象メンバーが存在するかチェック
+  const targetMembership = await prisma.circleMember.findUnique({
+    where: {
+      circleId_userId: {
+        circleId,
+        userId: memberId,
+      },
+    },
+  });
+
+  if (!targetMembership) {
+    return NextResponse.json(
+      { error: "このメンバーはサークルに参加していません" },
+      { status: 404 }
+    );
+  }
+
+  // メンバーシップを削除（投稿データはそのまま残す）
+  await prisma.circleMember.delete({
+    where: {
+      circleId_userId: {
+        circleId,
+        userId: memberId,
+      },
+    },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/circles/[circleId]/members/route.ts
+++ b/app/api/circles/[circleId]/members/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import prisma from "@/lib/prisma";
+
+type Params = {
+  params: Promise<{ circleId: string }>;
+};
+
+// サークルメンバー一覧を取得
+export async function GET(_request: Request, { params }: Params) {
+  const session = await auth();
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id as string;
+  const { circleId } = await params;
+
+  // 自分がこのサークルのADMINかチェック
+  const membership = await prisma.circleMember.findUnique({
+    where: {
+      circleId_userId: {
+        circleId,
+        userId,
+      },
+    },
+  });
+
+  if (!membership || membership.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "このサークルの管理権限がありません" },
+      { status: 403 }
+    );
+  }
+
+  // メンバー一覧を取得
+  const members = await prisma.circleMember.findMany({
+    where: { circleId },
+    select: {
+      userId: true,
+      role: true,
+      user: {
+        select: {
+          id: true,
+          name: true,
+          displayName: true,
+          image: true,
+        },
+      },
+    },
+  });
+
+  const formattedMembers = members.map((m) => ({
+    userId: m.userId,
+    role: m.role,
+    name: m.user.displayName || m.user.name || "不明",
+    image: m.user.image,
+  }));
+
+  return NextResponse.json({ members: formattedMembers });
+}

--- a/app/api/circles/[circleId]/route.ts
+++ b/app/api/circles/[circleId]/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import prisma from "@/lib/prisma";
+
+type Params = {
+  params: Promise<{ circleId: string }>;
+};
+
+// サークルを削除
+export async function DELETE(_request: Request, { params }: Params) {
+  const session = await auth();
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = session.user.id as string;
+  const { circleId } = await params;
+
+  // 自分がこのサークルのADMINかチェック
+  const membership = await prisma.circleMember.findUnique({
+    where: {
+      circleId_userId: {
+        circleId,
+        userId,
+      },
+    },
+  });
+
+  if (!membership || membership.role !== "ADMIN") {
+    return NextResponse.json(
+      { error: "このサークルの管理権限がありません" },
+      { status: 403 }
+    );
+  }
+
+  // メンバー数をチェック（ADMIN1人のみの場合のみ削除可能）
+  const memberCount = await prisma.circleMember.count({
+    where: { circleId },
+  });
+
+  if (memberCount > 1) {
+    return NextResponse.json(
+      { error: "他のメンバーがいるサークルは削除できません" },
+      { status: 400 }
+    );
+  }
+
+  // サークルを削除（onDelete: Cascadeで関連データも削除される）
+  await prisma.circle.delete({
+    where: { id: circleId },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,7 +2,6 @@ import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import prisma from "@/lib/prisma";
 import UnifiedChat from "../componets/UnifiedChat";
-import BalanceHeader from "../componets/BalanceHeader";
 import Link from "next/link";
 
 type FeedItem = {
@@ -299,17 +298,6 @@ export default async function DashboardPage() {
   return (
     <div className="h-dvh bg-white overflow-hidden">
       <div className="mx-auto max-w-md flex flex-col h-full">
-        {/* 合計残高（上部固定） */}
-        <div className="flex-shrink-0 bg-white px-3 pt-1 pb-1">
-          <BalanceHeader
-            totalBalance={totalBalance}
-            balanceDiff={balanceDiff}
-            yesterdayBalance={yesterdayBalance}
-            monthlyExpense={monthlyExpense}
-            circleBalances={circleBalances}
-          />
-        </div>
-
         {/* メインコンテンツ */}
         {!hasCircles ? (
           <div className="flex-1 flex items-center justify-center text-center px-6">
@@ -336,6 +324,9 @@ export default async function DashboardPage() {
             currentUserId={userId}
             userRoles={memberships.map((m) => ({ circleId: m.circleId, role: m.role }))}
             tagSummary={tagSummary}
+            initialTotalBalance={totalBalance}
+            initialMonthlyExpense={monthlyExpense}
+            adminCircleIds={adminCircleIds}
           />
         )}
       </div>


### PR DESCRIPTION
## [app/componets/UnifiedChat.tsx](vscode-webview://01oeojgdo4nme5jioq0eum2t3im5rrqn5pl3d89aa87dvesol0hk/app/componets/UnifiedChat.tsx)
- Props に initialTotalBalance, initialMonthlyExpense, adminCircleIds を追加
- totalBalance, monthlyExpense, isBreakdownOpen の状態を追加
- BalanceHeaderのUIをUnifiedChat内に統合
- 支出登録時：サークル残高と合計残高を更新、当月支出も加算
- 収入登録時：サークル残高と合計残高を更新
- 残高更新時：旧残高との差分を計算して合計残高を更新
- 削除時：合計残高と当月支出も反映
## [app/dashboard/page.tsx](vscode-webview://01oeojgdo4nme5jioq0eum2t3im5rrqn5pl3d89aa87dvesol0hk/app/dashboard/page.tsx)
- BalanceHeaderのimportと表示を削除
- UnifiedChatに新しいprops（initialTotalBalance, initialMonthlyExpense, adminCircleIds）を追加