### PR TITLE
feat: 収入タグ選択UIを追加 / 当月支出サマリをDB直接集計に変更

### DIFF
--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
   const userId = session.user.id as string;
 
   try {
-    const { circleId, text } = await request.json();
+    const { circleId, text, tags: extraTags = [] } = await request.json();
 
     if (!circleId || !text) {
       return NextResponse.json(
@@ -73,7 +73,8 @@ export async function POST(request: Request) {
     });
     const incomeDate = new Date();
     let autoTags: string[] = [];
-    if (userPref?.autoTagEnabled && parsed.tags.length === 0) {
+    const mergedTags = [...new Set([...parsed.tags, ...extraTags])];
+    if (userPref?.autoTagEnabled && mergedTags.length === 0) {
       autoTags = await computeAutoTagsForIncome(
         circleId,
         parsed.amount,
@@ -90,7 +91,7 @@ export async function POST(request: Request) {
         description: text,
         source: parsed.place,
         category,
-        tags: parsed.tags,
+        tags: mergedTags,
         autoTags,
         incomeDate,
       },

--- a/app/componets/UnifiedChat.tsx
+++ b/app/componets/UnifiedChat.tsx
@@ -287,6 +287,7 @@ export default function UnifiedChat({
   );
   const [inputMode, setInputMode] = useState<InputMode>("expense");
   const [input, setInput] = useState("");
+  const [incomeTags, setIncomeTags] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
@@ -1724,6 +1725,7 @@ export default function UnifiedChat({
           body: JSON.stringify({
             circleId: selectedCircleId,
             text: submitInput.trim(),
+            tags: incomeTags,
           }),
         });
 
@@ -1733,6 +1735,8 @@ export default function UnifiedChat({
           setError(data.error || "エラーが発生しました");
           return;
         }
+
+        setIncomeTags([]);
 
         const newItem: FeedItem = {
           id: `income-${data.income.id}`,
@@ -3020,6 +3024,29 @@ export default function UnifiedChat({
         {/* 入力フォーム：モード切替 + 入力 + 送信（タイムライン時は非表示） */}
         {!isTimeline && (
           <form onSubmit={handleSubmit} className="px-3 pb-3 pt-1">
+            {/* 収入タグ選択 */}
+            {inputMode === "income" && (
+              <div className="flex flex-wrap gap-1.5 pb-2">
+                {["給料", "副業", "ボーナス", "家賃", "売上", "投資", "仕送り"].map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() =>
+                      setIncomeTags((prev) =>
+                        prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+                      )
+                    }
+                    className={`text-[11px] px-2.5 py-0.5 rounded-full border transition ${
+                      incomeTags.includes(tag)
+                        ? "bg-emerald-600 text-white border-emerald-600"
+                        : "bg-white text-slate-600 border-slate-300 hover:border-emerald-400"
+                    }`}
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
             <div className="flex items-center gap-2">
               {/* モード切替トグル */}
               <div className="flex-shrink-0 flex bg-slate-100 rounded-lg p-0.5">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -226,19 +226,21 @@ export default async function DashboardPage({
     const jstMonth = jstNow.getUTCMonth();
     const jstDate = jstNow.getUTCDate();
 
-    // 当月の月次集計を取得（全サークル分）
-    const yearMonth = `${jstYear}${String(jstMonth + 1).padStart(2, "0")}`;
-    const monthlySnapshotsAll = await prisma.monthlySnapshot.findMany({
+    // 当月の支出を直接集計（MonthlySnapshotのUTC/JST不整合を回避）
+    const startOfMonth = new Date(
+      Date.UTC(jstYear, jstMonth, 1) - 9 * 60 * 60 * 1000,
+    );
+    const monthlyExpenseByCircle = await prisma.expense.groupBy({
+      by: ["circleId"],
       where: {
         circleId: { in: circleIds },
-        yearMonth,
+        createdAt: { gte: startOfMonth },
       },
+      _sum: { amount: true },
     });
-
-    // サークルごとのMonthlySnapshotをマップに変換
-    const monthlySnapshotMap = new Map<string, number>();
-    for (const ms of monthlySnapshotsAll) {
-      monthlySnapshotMap.set(ms.circleId, ms.totalExpense);
+    const monthlyExpenseMap = new Map<string, number>();
+    for (const item of monthlyExpenseByCircle) {
+      monthlyExpenseMap.set(item.circleId, item._sum.amount || 0);
     }
 
     // 全期間の支出をサークルごとに集計
@@ -267,7 +269,7 @@ export default async function DashboardPage({
 
     for (const circleId of circleIds) {
       const circleData = circlesWithAdmin.find((c) => c.id === circleId);
-      const circleMonthlyExpense = monthlySnapshotMap.get(circleId) || 0;
+      const circleMonthlyExpense = monthlyExpenseMap.get(circleId) || 0;
       const circleAllTimeExpense = allTimeExpenseMap.get(circleId) || 0;
 
       // サークル別残高リストに追加（currentBalanceキャッシュを使用）


### PR DESCRIPTION
- 収入入力モードにタグ選択チップを追加（給料/副業/ボーナス等）
- income APIがtagsフィールドを受け取りparsed.tagsとマージ
- ダッシュボードの当月支出をMonthlySnapshot(UTC)ではなく Expense直接集計(JST月初起点)で計算するよう修正